### PR TITLE
pin binfmt version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,62 +4,70 @@ description: Prepare the environment and run docker buildx build.
 author: support@senzing.com
 
 inputs:
-   build-options:
-      description: Additional options to pass to docker buildx build
-   context:
-      default: "."
-      description: Context (directory) of the docker build process
-   image-repository:
-      description: Docker repository (e.g. senzing/senzingapi-runtime)
-      required: true
-   image-tag:
-      default: latest
-      description: Docker image tag
-   password:
-      description: Access Token for Docker registry
-      required: true
-   platforms:
-      default: linux/amd64,linux/arm64
-      description: Comma-separated list of docker platforms to build (hint - See output of docker buildx ls)
-   registry-server:
-      default: docker.io
-      description: Docker registry server
-   username:
-      description: Username for Docker registry
-      required: true
+  build-options:
+    description: Additional options to pass to docker buildx build
+  context:
+    default: "."
+    description: Context (directory) of the docker build process
+  image-repository:
+    description: Docker repository (e.g. senzing/senzingapi-runtime)
+    required: true
+  image-tag:
+    default: latest
+    description: Docker image tag
+  password:
+    description: Access Token for Docker registry
+    required: true
+  platforms:
+    default: linux/amd64,linux/arm64
+    description: Comma-separated list of docker platforms to build (hint - See output of docker buildx ls)
+  registry-server:
+    default: docker.io
+    description: Docker registry server
+  username:
+    description: Username for Docker registry
+    required: true
 
 runs:
-   using: composite
-   steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-           fetch-depth: "0"
-           submodules: recursive
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker list platforms
-        run: docker buildx ls
-        shell: bash
-      - name: Dockerhub login
-        uses: docker/login-action@v3
-        with:
-           registry: ${{ inputs.registry-server }}
-           username: ${{ inputs.username }}
-           password: ${{ inputs.password }}
-      - name: Docker build images
-        run: |
-           CLEANED_TAG=$(echo ${{ inputs.image-tag }} | tr -d "/#" )
-           docker buildx build \
-              --platform ${{ inputs.platforms }} \
-              --tag ${{ inputs.registry-server }}/${{ inputs.image-repository }}:$CLEANED_TAG \
-              --tag ${{ inputs.registry-server }}/${{ inputs.image-repository }}:latest \
-              ${{ inputs.build-options }} \
-              ${{ inputs.context }}
-        shell: bash
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: "0"
+        submodules: recursive
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      # https://github.com/docker/setup-qemu-action/issues/198
+      with:
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker list platforms
+      run: docker buildx ls
+      shell: bash
+
+    - name: Dockerhub login
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry-server }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Docker build images
+      run: |
+        CLEANED_TAG=$(echo ${{ inputs.image-tag }} | tr -d "/#" )
+        docker buildx build \
+           --platform ${{ inputs.platforms }} \
+           --tag ${{ inputs.registry-server }}/${{ inputs.image-repository }}:$CLEANED_TAG \
+           --tag ${{ inputs.registry-server }}/${{ inputs.image-repository }}:latest \
+           ${{ inputs.build-options }} \
+           ${{ inputs.context }}
+      shell: bash
 
 branding:
-   icon: upload-cloud
-   color: green
+  icon: upload-cloud
+  color: green


### PR DESCRIPTION
```
After some digging I'm pretty sure this issue relates to a kernel hardening. This also explains why various qemu versions are affected. More details can be found in this Debian bug: [1]. This bug first happened after [2] was applied (which later was reverted) and reverted again [3] after a fix for QEMU in Debian was available. Probably Ubuntu included just the kernel patch (revert-revert) but not the QEMU patch which then broke things again.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087822.
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=44c76825d6eefee9eb7ce06c38e1a6632ac7eb7d
[3] https://tracker.debian.org/news/1601333/accepted-linux-signed-amd64-611231-source-into-proposed-updates/
```

See details:
https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2613004741
https://github.com/docker/setup-qemu-action/issues/198